### PR TITLE
Feature: Add PDF signature information

### DIFF
--- a/src/main/java/org/jadice/filetype/matchers/PDFMatcher.java
+++ b/src/main/java/org/jadice/filetype/matchers/PDFMatcher.java
@@ -35,6 +35,7 @@ import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationFileAttachme
 import org.jadice.filetype.Context;
 import org.jadice.filetype.database.MimeTypeAction;
 import org.jadice.filetype.io.SeekableInputStream;
+import org.jadice.filetype.pdfutil.SignatureUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,6 +121,7 @@ public class PDFMatcher extends Matcher {
 
         if (!filenames.isEmpty())
           pdfDetails.put(EMBEDDED_FILE_NAMES_KEY, filenames);
+        SignatureUtil.addSignatureInfo(pdfDetails, document, sis.length());
       }
 
       return true;

--- a/src/main/java/org/jadice/filetype/matchers/PDFMatcher.java
+++ b/src/main/java/org/jadice/filetype/matchers/PDFMatcher.java
@@ -36,7 +36,6 @@ import org.jadice.filetype.Context;
 import org.jadice.filetype.database.MimeTypeAction;
 import org.jadice.filetype.io.SeekableInputStream;
 import org.jadice.filetype.pdfutil.PDFBoxSignatureUtil;
-import org.jadice.filetype.pdfutil.SignatureUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/jadice/filetype/matchers/PDFMatcher.java
+++ b/src/main/java/org/jadice/filetype/matchers/PDFMatcher.java
@@ -35,6 +35,7 @@ import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationFileAttachme
 import org.jadice.filetype.Context;
 import org.jadice.filetype.database.MimeTypeAction;
 import org.jadice.filetype.io.SeekableInputStream;
+import org.jadice.filetype.pdfutil.PDFBoxSignatureUtil;
 import org.jadice.filetype.pdfutil.SignatureUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -121,7 +122,7 @@ public class PDFMatcher extends Matcher {
 
         if (!filenames.isEmpty())
           pdfDetails.put(EMBEDDED_FILE_NAMES_KEY, filenames);
-        SignatureUtil.addSignatureInfo(pdfDetails, document, sis.length());
+        PDFBoxSignatureUtil.addSignatureInfo(pdfDetails, document, sis.length());
       }
 
       return true;

--- a/src/main/java/org/jadice/filetype/matchers/PDFMatcher.java
+++ b/src/main/java/org/jadice/filetype/matchers/PDFMatcher.java
@@ -75,6 +75,7 @@ public class PDFMatcher extends Matcher {
   public boolean matches(final Context context) {
     SeekableInputStream sis = context.getStream();
     try {
+      long fileLength = getFileLength(sis);
       sis.seek(0);
       try (PDDocument document = PDDocument.load(sis)) {
         context.setProperty(MimeTypeAction.KEY, PDF_MIME_TYPE);
@@ -121,7 +122,7 @@ public class PDFMatcher extends Matcher {
 
         if (!filenames.isEmpty())
           pdfDetails.put(EMBEDDED_FILE_NAMES_KEY, filenames);
-        PDFBoxSignatureUtil.addSignatureInfo(pdfDetails, document, sis.length());
+        PDFBoxSignatureUtil.addSignatureInfo(pdfDetails, document, fileLength);
       }
 
       return true;
@@ -230,5 +231,29 @@ public class PDFMatcher extends Matcher {
       }
     }
     return embeddedFile;
+  }
+
+  /**
+   * Reads the whole stream to determine the length of it.
+   * @param sis stream
+   * @return length of given stream or -1 if any error occurred
+   */
+  private static long getFileLength(final SeekableInputStream sis) {
+    try {
+      sis.seek(0);
+      int read = 0;
+      final byte[] buffer = new byte[4096];
+      do {
+        synchronized (sis) { // perform synchronization inside while loop! See DOCPV-932
+          read = sis.read(buffer);
+        }
+      } while (read != -1);
+
+      // whole sis is read now
+      return sis.length();
+    } catch (Exception e) {
+      LOGGER.warn("Failed to determine file length.", e);
+      return -1;
+    }
   }
 }

--- a/src/main/java/org/jadice/filetype/matchers/PDFMatcher.java
+++ b/src/main/java/org/jadice/filetype/matchers/PDFMatcher.java
@@ -75,7 +75,6 @@ public class PDFMatcher extends Matcher {
   public boolean matches(final Context context) {
     SeekableInputStream sis = context.getStream();
     try {
-      long fileLength = getFileLength(sis);
       sis.seek(0);
       try (PDDocument document = PDDocument.load(sis)) {
         context.setProperty(MimeTypeAction.KEY, PDF_MIME_TYPE);
@@ -122,6 +121,11 @@ public class PDFMatcher extends Matcher {
 
         if (!filenames.isEmpty())
           pdfDetails.put(EMBEDDED_FILE_NAMES_KEY, filenames);
+
+        long fileLength = -1; // won't be used if there are no signatures in the PDF
+        if (document.getSignatureFields().size() > 0) {
+          fileLength = getFileLength(sis);
+        }
         PDFBoxSignatureUtil.addSignatureInfo(pdfDetails, document, fileLength);
       }
 

--- a/src/main/java/org/jadice/filetype/pdfutil/PDFBoxSignatureUtil.java
+++ b/src/main/java/org/jadice/filetype/pdfutil/PDFBoxSignatureUtil.java
@@ -1,0 +1,107 @@
+package org.jadice.filetype.pdfutil;
+
+import org.apache.pdfbox.cos.COSDictionary;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageTree;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationWidget;
+import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSignature;
+import org.apache.pdfbox.pdmodel.interactive.form.PDSignatureField;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Signature utility class that uses PDFBox to analyse PDFs.
+ */
+public class PDFBoxSignatureUtil extends SignatureUtil {
+
+  private PDFBoxSignatureUtil() {
+    // static utility class
+  }
+
+  /**
+   * Adds information about the given PDF document to the given map at the keys defined in {@link SignatureUtil}.
+   * @param pdfDetails pdf details map that should be enriched with PDF signature information
+   * @param document pdf document
+   * @param fileLen length of pdf document
+   */
+  public static void addSignatureInfo(final Map<String, Object> pdfDetails, final PDDocument document, final long fileLen) {
+    int counter = 0;
+    try {
+      List<Map<String,Object>> signatures = new ArrayList<>();
+      for (final PDSignatureField signatureField : document.getSignatureFields()) {
+        final PDSignature sig = signatureField.getSignature();
+
+        Map<String,Object> signatureDetails = new HashMap<>();
+        signatureDetails.put(SIGNATURE_NUMBER_KEY, ++counter);
+        signatureDetails.put(SIGNATURE_NAME_KEY, sig.getName());
+        signatureDetails.put(SIGNATURE_DATE_KEY, sig.getSignDate());
+        signatureDetails.put(SIGNATURE_CONTACT_INFO_KEY, sig.getContactInfo());
+        signatureDetails.put(SIGNATURE_LOCATION_KEY, sig.getLocation());
+        signatureDetails.put(SIGNATURE_REASON_KEY, sig.getReason());
+        signatureDetails.put(SIGNATURE_DOCUMENT_COVERAGE_KEY, determineCoverageOfSignature(sig.getByteRange(), sig.getContents().length, fileLen));
+        signatureDetails.put(SIGNATURE_PAGE_KEY, determinePageOfSignature(signatureField, document));
+        signatureDetails.put(SIGNATURE_SUB_FILTER_KEY, sig.getSubFilter());
+        signatures.add(signatureDetails);
+      }
+      if (counter > 0) {
+        pdfDetails.put(IS_SIGNED_KEY, true);
+        pdfDetails.put(SIGNATURE_DETAILS_KEY, signatures);
+      } else
+        pdfDetails.put(IS_SIGNED_KEY, false);
+    } catch (Exception e) {
+      LOGGER.warn("Failed to add signature information.", e);
+    }
+  }
+
+  /**
+   * Tries to determine the page of the given signature field. If this is not successful,
+   * the cause for it is logged and null returned.
+   * <p>
+   * Inspired by <a href="https://stackoverflow.com/a/22132921/19199839">this</a>.
+   *
+   * @param signatureField signature field
+   * @param document document
+   * @return 1-based page index of the given signature, or null of page could not be determined
+   */
+  public static Integer determinePageOfSignature(final PDSignatureField signatureField, final PDDocument document) {
+    if (signatureField.getWidgets().size() != 1) {
+      LOGGER.debug("Could not determine page of signature because " +
+          "the given signature field does not contain exactly 1 widget.");
+      return null;
+    }
+
+    final PDAnnotationWidget widget = signatureField.getWidgets().get(0);
+    final COSDictionary widgetObject = widget.getCOSObject();
+    final PDPageTree pages = document.getPages();
+
+    // fast method
+    final PDPage page = widget.getPage();
+    if (page != null) {
+      int pageIndex = pages.indexOf(page);
+      if (pageIndex != -1)
+        return pageIndex + 1;
+    }
+
+    // safe method
+    try {
+      for (int i = 0; i < pages.getCount(); i++) {
+        for (PDAnnotation annotation : pages.get(i).getAnnotations()) {
+          COSDictionary annotationObject = annotation.getCOSObject();
+          if (annotationObject.equals(widgetObject))
+            return i + 1;
+        }
+      }
+    } catch (Exception e) {
+      LOGGER.warn("Error occurred while trying to determine page of signature.", e);
+    }
+
+    LOGGER.debug("Failed to determine page of signature with fast and safe method.");
+    return null;
+  }
+
+}

--- a/src/main/java/org/jadice/filetype/pdfutil/PDFBoxSignatureUtil.java
+++ b/src/main/java/org/jadice/filetype/pdfutil/PDFBoxSignatureUtil.java
@@ -9,10 +9,8 @@ import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationWidget;
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSignature;
 import org.apache.pdfbox.pdmodel.interactive.form.PDSignatureField;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Signature utility class that uses PDFBox to analyse PDFs.
@@ -36,6 +34,8 @@ public class PDFBoxSignatureUtil extends SignatureUtil {
       for (final PDSignatureField signatureField : document.getSignatureFields()) {
         final PDSignature sig = signatureField.getSignature();
 
+        final List<Integer> byteRange = Arrays.stream(sig.getByteRange()).boxed().collect(Collectors.toList());
+
         Map<String,Object> signatureDetails = new HashMap<>();
         signatureDetails.put(SIGNATURE_NUMBER_KEY, ++counter);
         signatureDetails.put(SIGNATURE_NAME_KEY, sig.getName());
@@ -43,7 +43,7 @@ public class PDFBoxSignatureUtil extends SignatureUtil {
         signatureDetails.put(SIGNATURE_CONTACT_INFO_KEY, sig.getContactInfo());
         signatureDetails.put(SIGNATURE_LOCATION_KEY, sig.getLocation());
         signatureDetails.put(SIGNATURE_REASON_KEY, sig.getReason());
-        signatureDetails.put(SIGNATURE_DOCUMENT_COVERAGE_KEY, determineCoverageOfSignature(sig.getByteRange(), sig.getContents().length, fileLen));
+        signatureDetails.put(SIGNATURE_DOCUMENT_COVERAGE_KEY, determineCoverageOfSignature(byteRange, sig.getContents().length, fileLen));
         signatureDetails.put(SIGNATURE_PAGE_KEY, determinePageOfSignature(signatureField, document));
         signatureDetails.put(SIGNATURE_SUB_FILTER_KEY, sig.getSubFilter());
         signatures.add(signatureDetails);

--- a/src/main/java/org/jadice/filetype/pdfutil/SignatureUtil.java
+++ b/src/main/java/org/jadice/filetype/pdfutil/SignatureUtil.java
@@ -1,0 +1,117 @@
+package org.jadice.filetype.pdfutil;
+
+import org.apache.pdfbox.cos.COSDictionary;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageTree;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationWidget;
+import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSignature;
+import org.apache.pdfbox.pdmodel.interactive.form.PDSignatureField;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SignatureUtil {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SignatureUtil.class);
+
+  public static final String IS_SIGNED_KEY = "is-signed";
+
+  public static final String SIGNATURE_DETAILS_KEY = "SIGNATURE_DETAILS";
+
+  public static void addSignatureInfo(final Map<String, Object> pdfDetails, final PDDocument document, final long fileLen) {
+    int counter = 0;
+    try {
+      List<Map<String,Object>> signatures = new ArrayList<>();
+      for (PDSignatureField signatureField : document.getSignatureFields()) {
+        final PDSignature sig = signatureField.getSignature();
+        Integer page = null;
+        if (signatureField.getWidgets().size() == 1) {
+          page = determinePageOfSignature(document, signatureField.getWidgets().get(0));
+        } else {
+          LOGGER.warn("Failed to determine signature's page because PDSignatureField has more than one widget ({})!",
+              signatureField.getWidgets().size());
+        }
+        final String coverage = determineSignatureCoverage(sig, fileLen);
+
+        Map<String,Object> signatureDetails = new HashMap<>();
+        signatureDetails.put("number", ++counter);
+        signatureDetails.put("name", sig.getName());
+        signatureDetails.put("date", sig.getSignDate());
+        signatureDetails.put("contact-info", sig.getContactInfo());
+        signatureDetails.put("location", sig.getLocation());
+        signatureDetails.put("reason", sig.getReason());
+        signatureDetails.put("document-coverage", coverage);
+        signatureDetails.put("page", page);
+        signatureDetails.put("sub-filter", sig.getSubFilter());
+        signatures.add(signatureDetails);
+      }
+      if (counter > 0) {
+        pdfDetails.put(IS_SIGNED_KEY, true);
+        pdfDetails.put(SIGNATURE_DETAILS_KEY, signatures);
+      } else
+        pdfDetails.put(IS_SIGNED_KEY, false);
+    } catch (Exception e) {
+      LOGGER.warn("Failed to add signature information.", e);
+    }
+  }
+
+  /**
+   * Determines the page of the given widget.
+   *
+   * @param document document
+   * @param widget   widget
+   * @return page of the given widget, starting with 1 or null of page could not be determined
+   */
+  private static Integer determinePageOfSignature(final PDDocument document, final PDAnnotationWidget widget) {
+    final COSDictionary widgetObject = widget.getCOSObject();
+    final PDPageTree pages = document.getPages();
+    try {
+      for (int i = 0; i < pages.getCount(); i++) {
+        for (PDAnnotation annotation : pages.get(i).getAnnotations()) {
+          COSDictionary annotationObject = annotation.getCOSObject();
+          if (annotationObject.equals(widgetObject))
+            return i + 1;
+        }
+      }
+    } catch (Exception ignored) {
+    }
+    // second try to find out page
+    final PDPage page = widget.getPage();
+    return page != null ? pages.indexOf(page) + 1 : null;
+  }
+
+  /**
+   * Determines whether the given signature covers the whole document or only parts of it.
+   * In case of any error,  is returned.
+   *
+   * @param sig     signature
+   * @param fileLen length of PDF
+   * @return signature coverage
+   */
+  private static String determineSignatureCoverage(final PDSignature sig, final long fileLen) {
+    int[] byteRange = sig.getByteRange();
+    if (byteRange.length == 4) {
+      long rangeMax = byteRange[2] + (long) byteRange[3];
+      // multiply content length with 2 (because it is in hex in the PDF) and add 2 for < and >
+      int contentLen = sig.getContents().length * 2 + 2;
+      if (fileLen != rangeMax || byteRange[0] != 0 || byteRange[1] + contentLen != byteRange[2]) {
+        // a false result doesn't necessarily mean that the PDF is a fake
+        // see this answer why:
+        // https://stackoverflow.com/a/48185913/535646
+        return "PARTS";
+      } else {
+        return "WHOLE_DOCUMENT";
+      }
+    } else {
+      LOGGER.warn("Signature byteRange did not have length 4, but {}!", byteRange.length);
+      return "NOT_DETERMINED";
+    }
+  }
+
+}

--- a/src/main/java/org/jadice/filetype/pdfutil/SignatureUtil.java
+++ b/src/main/java/org/jadice/filetype/pdfutil/SignatureUtil.java
@@ -24,6 +24,10 @@ public class SignatureUtil {
 
   public static final String SIGNATURE_DETAILS_KEY = "SIGNATURE_DETAILS";
 
+  private SignatureUtil() {
+    // static utility class
+  }
+
   public static void addSignatureInfo(final Map<String, Object> pdfDetails, final PDDocument document, final long fileLen) {
     int counter = 0;
     try {
@@ -79,7 +83,8 @@ public class SignatureUtil {
             return i + 1;
         }
       }
-    } catch (Exception ignored) {
+    } catch (Exception e) {
+      LOGGER.error("Failed to determine page of signature at first try.", e);
     }
     // second try to find out page
     final PDPage page = widget.getPage();

--- a/src/main/java/org/jadice/filetype/pdfutil/SignatureUtil.java
+++ b/src/main/java/org/jadice/filetype/pdfutil/SignatureUtil.java
@@ -1,121 +1,58 @@
 package org.jadice.filetype.pdfutil;
 
-import org.apache.pdfbox.cos.COSDictionary;
-import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.pdmodel.PDPage;
-import org.apache.pdfbox.pdmodel.PDPageTree;
-import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
-import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationWidget;
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSignature;
-import org.apache.pdfbox.pdmodel.interactive.form.PDSignatureField;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+/**
+ * Abstract base class for signature util classes that declares the map keys
+ * for subclasses and implements default generic functions.
+ */
+public abstract class SignatureUtil {
 
-public class SignatureUtil {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(SignatureUtil.class);
+  protected static final Logger LOGGER = LoggerFactory.getLogger(SignatureUtil.class);
 
   public static final String IS_SIGNED_KEY = "is-signed";
 
   public static final String SIGNATURE_DETAILS_KEY = "SIGNATURE_DETAILS";
 
-  private SignatureUtil() {
-    // static utility class
-  }
-
-  public static void addSignatureInfo(final Map<String, Object> pdfDetails, final PDDocument document, final long fileLen) {
-    int counter = 0;
-    try {
-      List<Map<String,Object>> signatures = new ArrayList<>();
-      for (PDSignatureField signatureField : document.getSignatureFields()) {
-        final PDSignature sig = signatureField.getSignature();
-        Integer page = null;
-        if (signatureField.getWidgets().size() == 1) {
-          page = determinePageOfSignature(document, signatureField.getWidgets().get(0));
-        } else {
-          LOGGER.warn("Failed to determine signature's page because PDSignatureField has more than one widget ({})!",
-              signatureField.getWidgets().size());
-        }
-        final String coverage = determineSignatureCoverage(sig, fileLen);
-
-        Map<String,Object> signatureDetails = new HashMap<>();
-        signatureDetails.put("number", ++counter);
-        signatureDetails.put("name", sig.getName());
-        signatureDetails.put("date", sig.getSignDate());
-        signatureDetails.put("contact-info", sig.getContactInfo());
-        signatureDetails.put("location", sig.getLocation());
-        signatureDetails.put("reason", sig.getReason());
-        signatureDetails.put("document-coverage", coverage);
-        signatureDetails.put("page", page);
-        signatureDetails.put("sub-filter", sig.getSubFilter());
-        signatures.add(signatureDetails);
-      }
-      if (counter > 0) {
-        pdfDetails.put(IS_SIGNED_KEY, true);
-        pdfDetails.put(SIGNATURE_DETAILS_KEY, signatures);
-      } else
-        pdfDetails.put(IS_SIGNED_KEY, false);
-    } catch (Exception e) {
-      LOGGER.warn("Failed to add signature information.", e);
-    }
-  }
+  public static final String SIGNATURE_NUMBER_KEY = "number";
+  public static final String SIGNATURE_NAME_KEY = "name";
+  public static final String SIGNATURE_DATE_KEY = "date";
+  public static final String SIGNATURE_CONTACT_INFO_KEY = "contact-info";
+  public static final String SIGNATURE_LOCATION_KEY = "location";
+  public static final String SIGNATURE_REASON_KEY = "reason";
+  public static final String SIGNATURE_DOCUMENT_COVERAGE_KEY = "document-coverage";
+  public static final String SIGNATURE_PAGE_KEY = "page";
+  public static final String SIGNATURE_SUB_FILTER_KEY = "sub-filter";
 
   /**
-   * Determines the page of the given widget.
+   * Determines whether the given signature covers the whole
+   * document ("WHOLE_DOCUMENT") or only parts of it ("PARTS").
+   * Requires that the given byteRange array has length 4. If that's not the
+   * case, "NOT_DETERMINED" is returned.
+   * In case of any error, "NOT_DETERMINED" is returned.
+   * <p>
+   * This is inspired by <a href="https://github.com/apache/pdfbox/blob/535a7755a4b98bf225261ac58090e7c324e09b78/examples/src/main/java/org/apache/pdfbox/examples/signature/ShowSignature.java#L277">ShowSignature.java</a>.
+   * <p>
+   * <a href="https://stackoverflow.com/a/48185913/535646">Here</a> is explained why "PARTS" as result doesn't necessarily mean that the PDF is a fake.
    *
-   * @param document document
-   * @param widget   widget
-   * @return page of the given widget, starting with 1 or null of page could not be determined
-   */
-  private static Integer determinePageOfSignature(final PDDocument document, final PDAnnotationWidget widget) {
-    final COSDictionary widgetObject = widget.getCOSObject();
-    final PDPageTree pages = document.getPages();
-    try {
-      for (int i = 0; i < pages.getCount(); i++) {
-        for (PDAnnotation annotation : pages.get(i).getAnnotations()) {
-          COSDictionary annotationObject = annotation.getCOSObject();
-          if (annotationObject.equals(widgetObject))
-            return i + 1;
-        }
-      }
-    } catch (Exception e) {
-      LOGGER.error("Failed to determine page of signature at first try.", e);
-    }
-    // second try to find out page
-    final PDPage page = widget.getPage();
-    return page != null ? pages.indexOf(page) + 1 : null;
-  }
-
-  /**
-   * Determines whether the given signature covers the whole document or only parts of it.
-   * In case of any error,  is returned.
-   *
-   * @param sig     signature
-   * @param fileLen length of PDF
+   * @param byteRange byterange integer array, e.g. retrieved by {@link PDSignature#getByteRange()}
+   * @param signatureLength length of the signature's content, e.g. retrieved by the length attribute of {@link PDSignature#getContents()}
+   * @param fileLen length of PDF file
    * @return signature coverage
    */
-  private static String determineSignatureCoverage(final PDSignature sig, final long fileLen) {
-    int[] byteRange = sig.getByteRange();
-    if (byteRange.length == 4) {
-      long rangeMax = byteRange[2] + (long) byteRange[3];
-      // multiply content length with 2 (because it is in hex in the PDF) and add 2 for < and >
-      int contentLen = sig.getContents().length * 2 + 2;
-      if (fileLen != rangeMax || byteRange[0] != 0 || byteRange[1] + contentLen != byteRange[2]) {
-        // a false result doesn't necessarily mean that the PDF is a fake
-        // see this answer why:
-        // https://stackoverflow.com/a/48185913/535646
-        return "PARTS";
-      } else {
-        return "WHOLE_DOCUMENT";
-      }
-    } else {
-      LOGGER.warn("Signature byteRange did not have length 4, but {}!", byteRange.length);
+  public static String determineCoverageOfSignature(int[] byteRange, final int signatureLength, final long fileLen) {
+    if (byteRange.length != 4) {
       return "NOT_DETERMINED";
+    }
+    long rangeMax = byteRange[2] + (long) byteRange[3];
+    // multiply content length with 2 (because it is in hex in the PDF) and add 2 for < and >
+    int contentLen = signatureLength * 2 + 2;
+    if (fileLen != rangeMax || byteRange[0] != 0 || byteRange[1] + contentLen != byteRange[2]) {
+      return "PARTS";
+    } else {
+      return "WHOLE_DOCUMENT";
     }
   }
 

--- a/src/main/java/org/jadice/filetype/pdfutil/SignatureUtil.java
+++ b/src/main/java/org/jadice/filetype/pdfutil/SignatureUtil.java
@@ -4,6 +4,8 @@ import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+
 /**
  * Abstract base class for signature util classes that declares the map keys
  * for subclasses and implements default generic functions.
@@ -37,19 +39,19 @@ public abstract class SignatureUtil {
    * <p>
    * <a href="https://stackoverflow.com/a/48185913/535646">Here</a> is explained why "PARTS" as result doesn't necessarily mean that the PDF is a fake.
    *
-   * @param byteRange byterange integer array, e.g. retrieved by {@link PDSignature#getByteRange()}
+   * @param byteRange byterange integer List, e.g. retrieved by {@link PDSignature#getByteRange()} and casted to List
    * @param signatureLength length of the signature's content, e.g. retrieved by the length attribute of {@link PDSignature#getContents()}
    * @param fileLen length of PDF file
    * @return signature coverage
    */
-  public static String determineCoverageOfSignature(int[] byteRange, final int signatureLength, final long fileLen) {
-    if (byteRange.length != 4) {
+  public static String determineCoverageOfSignature(List<Integer> byteRange, final int signatureLength, final long fileLen) {
+    if (byteRange.size() != 4) {
       return "NOT_DETERMINED";
     }
-    long rangeMax = byteRange[2] + (long) byteRange[3];
+    long rangeMax = byteRange.get(2) + (long) byteRange.get(3);
     // multiply content length with 2 (because it is in hex in the PDF) and add 2 for < and >
     int contentLen = signatureLength * 2 + 2;
-    if (fileLen != rangeMax || byteRange[0] != 0 || byteRange[1] + contentLen != byteRange[2]) {
+    if (fileLen != rangeMax || byteRange.get(0) != 0 || byteRange.get(1) + contentLen != byteRange.get(2)) {
       return "PARTS";
     } else {
       return "WHOLE_DOCUMENT";

--- a/src/test/java/TestPDFMatcher.java
+++ b/src/test/java/TestPDFMatcher.java
@@ -143,13 +143,13 @@ class TestPDFMatcher {
       final List<Map<String,Object>> signatureList = (List<Map<String,Object>>) signatureDetails;
       assertThat(signatureList.size(), equalTo(expectedSignatureCount));
       for (Map<String, Object> signature : signatureList) {
-        assertThat(signature, hasKey("document-coverage"));
-        assertThat(signature, hasKey("page"));
-        assertThat(signature, hasKey("number"));
-        assertThat(signature.get("page"), notNullValue());
+        assertThat(signature, hasKey(SignatureUtil.SIGNATURE_DOCUMENT_COVERAGE_KEY));
+        assertThat(signature, hasKey(SignatureUtil.SIGNATURE_PAGE_KEY));
+        assertThat(signature, hasKey(SignatureUtil.SIGNATURE_NUMBER_KEY));
+        assertThat(signature.get(SignatureUtil.SIGNATURE_PAGE_KEY), notNullValue());
         if (expectedSignatureCount == 1) {
-          assertThat(signature.get("document-coverage"), equalTo("WHOLE_DOCUMENT"));
-          assertThat(signature.get("number"), equalTo(1));
+          assertThat(signature.get(SignatureUtil.SIGNATURE_DOCUMENT_COVERAGE_KEY), equalTo("WHOLE_DOCUMENT"));
+          assertThat(signature.get(SignatureUtil.SIGNATURE_NUMBER_KEY), equalTo(1));
         }
       }
     }

--- a/src/test/resources/pdf/signed.csv
+++ b/src/test/resources/pdf/signed.csv
@@ -1,0 +1,5 @@
+URL,signature-count
+https://github.com/levigo/sample-files/raw/main/pdf/PDF_signed_invisible.pdf,1
+https://github.com/levigo/sample-files/raw/main/pdf/PDF_signed_visible.pdf,1
+https://github.com/levigo/sample-files/raw/main/pdf/PDF_signed_invisible_visible.pdf,2
+https://github.com/levigo/sample-files/raw/main/pdf/PDF_unsigned.pdf,0


### PR DESCRIPTION
- The [SignatureUtil] class defines constants (map keys for the result map) and generic functions that don't refer to a specific PDF framework
- [PDFBoxSignatureUtil] inherits from this base class and adds functionality for the specific PDFBox use case. To use the documentplatform, a analog class that inherits from [SignatureUtil] will be created.

[SignatureUtil]: https://github.com/levigo/filetype-analyzer/blob/feature/pdf-signatures/src/main/java/org/jadice/filetype/pdfutil/SignatureUtil.java
[PDFBoxSignatureUtil]: https://github.com/levigo/filetype-analyzer/blob/feature/pdf-signatures/src/main/java/org/jadice/filetype/pdfutil/PDFBoxSignatureUtil.java