### PR TITLE
Feature/verify signatures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,6 +320,13 @@
       <version>${pdfbox.version}</version>
     </dependency>
 
+    <!-- for pdf signature validation -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.70</version>
+    </dependency>
+
     <!-- Using Hamcrest in a Maven Project see http://hamcrest.org/JavaHamcrest/distributables#maven-upgrade-example -->
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,8 @@
     <sonar.projectKey>levigo_filetype-analyzer</sonar.projectKey>
     <sonar.organization>levigo</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+
+    <bouncycastle.version>1.70</bouncycastle.version>
   </properties>
 
   <build>
@@ -324,7 +326,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.70</version>
+      <version>${bouncycastle.version}</version>
     </dependency>
 
     <!-- Using Hamcrest in a Maven Project see http://hamcrest.org/JavaHamcrest/distributables#maven-upgrade-example -->

--- a/src/main/java/org/jadice/filetype/matchers/PDFMatcher.java
+++ b/src/main/java/org/jadice/filetype/matchers/PDFMatcher.java
@@ -74,7 +74,7 @@ public class PDFMatcher extends Matcher {
 
   /*
    * (non-Javadoc)
-   *
+   * 
    * @see com.levigo.jadice.filetype.database.Matcher#matches(com.levigo.jadice.filetype.Context)
    */
   @Override
@@ -128,11 +128,7 @@ public class PDFMatcher extends Matcher {
         if (!filenames.isEmpty())
           pdfDetails.put(EMBEDDED_FILE_NAMES_KEY, filenames);
 
-        long fileLength = -1; // won't be used if there are no signatures in the PDF
-        if (document.getSignatureFields().size() > 0) {
-          fileLength = getFileLength(sis);
-        }
-        PDFBoxSignatureUtil.addSignatureInfo(pdfDetails, document, fileLength);
+        PDFBoxSignatureUtil.addSignatureInfo(pdfDetails, document, sis);
         if (lookForText())
           addTextInfo(pdfDetails, document);
       }

--- a/src/main/java/org/jadice/filetype/pdfutil/CMSProcessableInputStream.java
+++ b/src/main/java/org/jadice/filetype/pdfutil/CMSProcessableInputStream.java
@@ -1,0 +1,50 @@
+package org.jadice.filetype.pdfutil;
+
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.cms.CMSObjectIdentifiers;
+import org.bouncycastle.cms.CMSException;
+import org.bouncycastle.cms.CMSTypedData;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.pdfbox.io.IOUtils;
+
+/**
+ * Wraps a InputStream into a CMSProcessable object for bouncy castle. It's a memory saving
+ * alternative to the {@link org.bouncycastle.cms.CMSProcessableByteArray CMSProcessableByteArray}
+ * class.
+ *
+ * @author Thomas Chojecki
+ */
+class CMSProcessableInputStream implements CMSTypedData {
+  private final InputStream in;
+  private final ASN1ObjectIdentifier contentType;
+
+  CMSProcessableInputStream(InputStream is) {
+    this(new ASN1ObjectIdentifier(CMSObjectIdentifiers.data.getId()), is);
+  }
+
+  CMSProcessableInputStream(ASN1ObjectIdentifier type, InputStream is) {
+    contentType = type;
+    in = is;
+  }
+
+  @Override
+  public Object getContent() {
+    return in;
+  }
+
+  @Override
+  public void write(OutputStream out) throws IOException, CMSException {
+    // read the content only one time
+    IOUtils.copy(in, out);
+    in.close();
+  }
+
+  @Override
+  public ASN1ObjectIdentifier getContentType() {
+    return contentType;
+  }
+}

--- a/src/main/java/org/jadice/filetype/pdfutil/CMSProcessableInputStream.java
+++ b/src/main/java/org/jadice/filetype/pdfutil/CMSProcessableInputStream.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jadice.filetype.pdfutil;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;

--- a/src/main/java/org/jadice/filetype/pdfutil/PDFBoxSignatureUtil.java
+++ b/src/main/java/org/jadice/filetype/pdfutil/PDFBoxSignatureUtil.java
@@ -82,11 +82,15 @@ public class PDFBoxSignatureUtil extends SignatureUtil {
    * @return bytes of the "Cert" entry or null
    */
   private static byte[] getCertData(final PDSignature signature) {
-    if (PDSignature.SUBFILTER_ADBE_X509_RSA_SHA1.getName().equals(signature.getSubFilter())) {
-      final COSString certString = (COSString) signature.getCOSObject().getDictionaryObject(COSName.CERT);
-      return certString.getBytes();
+    try {
+      if (PDSignature.SUBFILTER_ADBE_X509_RSA_SHA1.getName().equals(signature.getSubFilter())) {
+        final COSString certString = (COSString) signature.getCOSObject().getDictionaryObject(COSName.CERT);
+        return certString.getBytes();
+      }
+      return null;
+    } catch (Exception e) {
+      return null;
     }
-    return null;
   }
 
   /**

--- a/src/main/java/org/jadice/filetype/pdfutil/PDFBoxSignatureUtil.java
+++ b/src/main/java/org/jadice/filetype/pdfutil/PDFBoxSignatureUtil.java
@@ -1,6 +1,8 @@
 package org.jadice.filetype.pdfutil;
 
 import org.apache.pdfbox.cos.COSDictionary;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.cos.COSString;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageTree;
@@ -58,7 +60,7 @@ public class PDFBoxSignatureUtil extends SignatureUtil {
           signatureDetails.put(SIGNATURE_PAGE_KEY, determinePageOfSignature(signatureField, document));
           signatureDetails.put(SIGNATURE_FILTER_KEY, sig.getFilter());
           signatureDetails.put(SIGNATURE_SUB_FILTER_KEY, sig.getSubFilter());
-          signatureDetails.put(SIGNATURE_VALIDITY, verifySignature(contents, signedContent, sig.getSubFilter(), sig.getSignDate()));
+          signatureDetails.put(SIGNATURE_VALIDITY, verifySignature(contents, signedContent, sig.getSubFilter(), sig.getSignDate(), getCertData(sig)));
         } catch (Exception e) {
           LOGGER.warn("Error occurred while analyzing signature.", e);
         }
@@ -71,6 +73,20 @@ public class PDFBoxSignatureUtil extends SignatureUtil {
     } catch (Exception e) {
       LOGGER.warn("Failed to add signature information.", e);
     }
+  }
+
+  /**
+   * Returns the bytes of the "Cert" entry of the signature's dictionary,
+   * but only if subfilter is "adbe.x509.rsa_sha1". For other subfilters null is returned.
+   * @param signature signature
+   * @return bytes of the "Cert" entry or null
+   */
+  private static byte[] getCertData(final PDSignature signature) {
+    if (PDSignature.SUBFILTER_ADBE_X509_RSA_SHA1.getName().equals(signature.getSubFilter())) {
+      final COSString certString = (COSString) signature.getCOSObject().getDictionaryObject(COSName.CERT);
+      return certString.getBytes();
+    }
+    return null;
   }
 
   /**

--- a/src/main/java/org/jadice/filetype/pdfutil/SignatureUtil.java
+++ b/src/main/java/org/jadice/filetype/pdfutil/SignatureUtil.java
@@ -1,9 +1,26 @@
 package org.jadice.filetype.pdfutil;
 
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSignature;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cms.*;
+import org.bouncycastle.cms.jcajce.JcaSimpleSignerInfoVerifierBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.tsp.TSPException;
+import org.bouncycastle.tsp.TimeStampToken;
+import org.bouncycastle.tsp.TimeStampTokenInfo;
+import org.jadice.filetype.io.SeekableInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.Arrays;
+import java.util.Calendar;
 import java.util.List;
 
 /**
@@ -26,7 +43,9 @@ public abstract class SignatureUtil {
   public static final String SIGNATURE_REASON_KEY = "reason";
   public static final String SIGNATURE_DOCUMENT_COVERAGE_KEY = "document-coverage";
   public static final String SIGNATURE_PAGE_KEY = "page";
+  public static final String SIGNATURE_FILTER_KEY = "filter";
   public static final String SIGNATURE_SUB_FILTER_KEY = "sub-filter";
+  public static final String SIGNATURE_VALIDITY = "validity";
 
   /**
    * Determines whether the given signature covers the whole
@@ -39,9 +58,9 @@ public abstract class SignatureUtil {
    * <p>
    * <a href="https://stackoverflow.com/a/48185913/535646">Here</a> is explained why "PARTS" as result doesn't necessarily mean that the PDF is a fake.
    *
-   * @param byteRange byterange integer List, e.g. retrieved by {@link PDSignature#getByteRange()} and casted to List
+   * @param byteRange       byterange integer List, e.g. retrieved by {@link PDSignature#getByteRange()} and casted to List
    * @param signatureLength length of the signature's content, e.g. retrieved by the length attribute of {@link PDSignature#getContents()}
-   * @param fileLen length of PDF file
+   * @param fileLen         length of PDF file
    * @return signature coverage
    */
   public static String determineCoverageOfSignature(List<Integer> byteRange, final int signatureLength, final long fileLen) {
@@ -56,6 +75,134 @@ public abstract class SignatureUtil {
     } else {
       return "WHOLE_DOCUMENT";
     }
+  }
+
+  /**
+   * Reads the whole stream to determine the length of it.
+   *
+   * @param sis stream
+   * @return length of given stream or -1 if any error occurred
+   */
+  protected static long getFileLength(final SeekableInputStream sis) {
+    try {
+      sis.seek(0);
+      int read = 0;
+      final byte[] buffer = new byte[4096];
+      do {
+        synchronized (sis) { // perform synchronization inside while loop! See DOCPV-932
+          read = sis.read(buffer);
+        }
+      } while (read != -1);
+
+      // whole sis is read now
+      return sis.length();
+    } catch (Exception e) {
+      LOGGER.warn("Failed to determine file length.", e);
+      return -1;
+    }
+  }
+
+  /**
+   * @param contents      the /Contents field as a COSString
+   * @param signedContent the byte sequence that has been signed
+   * @param subFilter     the subfilter of the signature
+   * @param signDate      the sign date of the signature
+   * @return string message which indicates whether the signature could be validated
+   */
+  public static String verifySignature(final byte[] contents, final InputStream signedContent, final String subFilter,
+                                       final Calendar signDate) {
+    try {
+      if (subFilter == null) return "Could not be validated. Missing subfilter.";
+      switch (subFilter) {
+        case "adbe.pkcs7.detached":
+        case "ETSI.CAdES.detached":
+          return verifyPKCS7(contents, signedContent, signDate);
+        case "adbe.pkcs7.sha1":
+//          CertificateFactory factory = CertificateFactory.getInstance("X.509");
+//          ByteArrayInputStream certStream = new ByteArrayInputStream(contents);
+//          Collection<? extends Certificate> certs = factory.generateCertificates(certStream);
+//          System.out.println("certs=" + certs);
+          @SuppressWarnings({"squid:S5542", "lgtm [java/weak-cryptographic-algorithm]"})
+          MessageDigest md = MessageDigest.getInstance("SHA1");
+          try (DigestInputStream dis = new DigestInputStream(signedContent, md)) {
+            while (dis.read() != -1) {
+            }
+          }
+          byte[] hash = md.digest();
+          return verifyPKCS7(contents, new ByteArrayInputStream(hash), signDate);
+        case "adbe.x509.rsa.sha1":
+        case "adbe.x509.rsa_sha1":
+          // TODO
+          return String.format("Could not be validated. SubFilter %s not yet supported.", subFilter);
+        case "ETSI.RFC3161":
+          return verifyETSIdotRFC3161(signedContent, contents);
+        default:
+          return String.format("Could not be validated. Unknown subfilter %s.", subFilter);
+      }
+    } catch (Exception e) {
+      LOGGER.warn("Error occurred while verification of signature.", e);
+      return "Could not be validated, error occurred: " + e.getMessage();
+    }
+  }
+
+  /**
+   * Verifies that the pkcs7 signature is valid.
+   * Inspired by: <a href="https://github.com/mkl-public/testarea-pdfbox2/blob/master/src/test/java/mkl/testarea/pdfbox2/sign/ValidateSignature.java#L198">...</a>
+   * TODO: Could be extended to more complex validation, like here: <a href="https://github.com/apache/pdfbox/blob/trunk/examples/src/main/java/org/apache/pdfbox/examples/signature/ShowSignature.java">...</a>
+   *
+   * @param contents      the /Contents field as a COSString
+   * @param signedContent the byte sequence that has been signed
+   * @param signDate      the sign date of the signature
+   * @return string message which indicates whether the signature could be validated
+   */
+  public static String verifyPKCS7(final byte[] contents, final InputStream signedContent, final Calendar signDate) {
+    try {
+      final CMSSignedData cms = new CMSSignedData(new CMSProcessableInputStream(signedContent), contents);
+      final SignerInformation signerInfo = cms.getSignerInfos().getSigners().iterator().next();
+      X509CertificateHolder cert = (X509CertificateHolder) cms.getCertificates().getMatches(signerInfo.getSID())
+          .iterator().next();
+      SignerInformationVerifier verifier = new JcaSimpleSignerInfoVerifierBuilder().setProvider(new BouncyCastleProvider()).build(cert);
+
+      return signerInfo.verify(verifier) ? "valid" : "Could not be validated";
+    } catch (Exception e) {
+      LOGGER.warn("Error occurred while verification of signature.", e);
+      return "Could not be validated, error occurred: " + e.getMessage();
+    }
+  }
+
+  /**
+   * Verify ETSI.RFC3161 TimeStampToken
+   * Copied from: <a href="https://github.com/apache/pdfbox/blob/trunk/examples/src/main/java/org/apache/pdfbox/examples/signature/ShowSignature.java">...</a>
+   *
+   * @param contents      the /Contents field as a COSString
+   * @param signedContent the byte sequence that has been signed
+   * @return string message which indicates whether the signature could be validated
+   */
+  public static String verifyETSIdotRFC3161(InputStream signedContent, byte[] contents)
+      throws CMSException, NoSuchAlgorithmException, IOException, TSPException, CertificateException {
+    TimeStampToken timeStampToken = new TimeStampToken(new CMSSignedData(contents));
+    TimeStampTokenInfo timeStampInfo = timeStampToken.getTimeStampInfo();
+
+    String hashAlgorithm = timeStampInfo.getMessageImprintAlgOID().getId();
+    // compare the hash of the signed content with the hash in the timestamp
+    MessageDigest md = MessageDigest.getInstance(hashAlgorithm);
+    try (DigestInputStream dis = new DigestInputStream(signedContent, md)) {
+      while (dis.read() != -1) {
+      }
+    }
+    return Arrays.equals(md.digest(), timeStampInfo.getMessageImprintDigest()) ? "valid" : "Could not be validated";
+
+//    CertificateFactory factory = CertificateFactory.getInstance("X.509");
+//    ByteArrayInputStream certStream = new ByteArrayInputStream(contents);
+//    Collection<? extends Certificate> certs = factory.generateCertificates(certStream);
+//    System.out.println("certs=" + certs);
+//
+//    X509Certificate certFromTimeStamp = (X509Certificate) certs.iterator().next();
+//    SigUtils.checkTimeStampCertificateUsage(certFromTimeStamp);
+//    SigUtils.validateTimestampToken(timeStampToken);
+//    SigUtils.verifyCertificateChain(timeStampToken.getCertificates(),
+//        certFromTimeStamp,
+//        timeStampInfo.getGenTime());
   }
 
 }

--- a/src/test/java/TestPDFMatcher.java
+++ b/src/test/java/TestPDFMatcher.java
@@ -130,7 +130,7 @@ class TestPDFMatcher {
   @SuppressWarnings("unchecked")
   @ParameterizedTest
   @CsvFileSource(resources = "/pdf/signed.csv", numLinesToSkip = 1)
-  void testSignedPDFs(final String urlString, final int expectedSignatureCount) throws IOException {
+  void testSignedPDFs(final String urlString, final int expectedSignatureCount, final boolean valid) throws IOException {
     final Map<String, Object> result = ANALYZER.analyze(new URL(urlString).openStream());
     assertNotNull(result);
     assertThat(result, hasKey(PDFMatcher.DETAILS_KEY));
@@ -146,23 +146,15 @@ class TestPDFMatcher {
         assertThat(signature, hasKey(SignatureUtil.SIGNATURE_NUMBER_KEY));
         assertThat(signature.get(SignatureUtil.SIGNATURE_PAGE_KEY), notNullValue());
         if (expectedSignatureCount == 1) {
-          assertThat(signature.get(SignatureUtil.SIGNATURE_DOCUMENT_COVERAGE_KEY), equalTo("WHOLE_DOCUMENT"));
+          if (valid)
+            assertThat(signature.get(SignatureUtil.SIGNATURE_DOCUMENT_COVERAGE_KEY), equalTo("WHOLE_DOCUMENT"));
           assertThat(signature.get(SignatureUtil.SIGNATURE_NUMBER_KEY), equalTo(1));
         }
-        System.out.println("Valid: " + signature.get(SignatureUtil.SIGNATURE_VALIDITY));
+        if (valid)
+          assertEquals("Valid", signature.get(SignatureUtil.SIGNATURE_VALIDITY));
+        else
+          assertTrue(((String) signature.get(SignatureUtil.SIGNATURE_VALIDITY)).startsWith("Could not be validated."));
       }
-    }
-  }
-
-  @Test // TODO delete
-  void test() throws IOException {
-    Map<String, Object> result = ANALYZER.analyze(new File("src/test/resources/pdf/adbe.pkcs7.sha1.pdf"));
-    Map<String,Object> pdfDetails = (Map<String,Object>) result.get(PDFMatcher.DETAILS_KEY);
-    List<Map<String,Object>> sigDetails = (List<Map<String,Object>>) pdfDetails.get(SignatureUtil.SIGNATURE_DETAILS_KEY);
-    for (Map<String, Object> sigDetail : sigDetails) {
-      System.out.println(sigDetail.get(SignatureUtil.SIGNATURE_FILTER_KEY));
-      System.out.println(sigDetail.get(SignatureUtil.SIGNATURE_SUB_FILTER_KEY));
-      System.out.println(sigDetail.get(SignatureUtil.SIGNATURE_VALIDITY));
     }
   }
 

--- a/src/test/java/TestPDFMatcher.java
+++ b/src/test/java/TestPDFMatcher.java
@@ -127,6 +127,7 @@ class TestPDFMatcher {
     assertNumberOfPages(result, 1);
   }
 
+  @SuppressWarnings("unchecked")
   @ParameterizedTest
   @CsvFileSource(resources = "/pdf/signed.csv", numLinesToSkip = 1)
   void testSignedPDFs(final String urlString, final int expectedSignatureCount) throws IOException {
@@ -134,12 +135,9 @@ class TestPDFMatcher {
     assertNotNull(result);
     assertThat(result, hasKey(PDFMatcher.DETAILS_KEY));
     final Map<String, Object> details = (Map<String, Object>) result.get(PDFMatcher.DETAILS_KEY);
-    assertThat(details, hasKey(SignatureUtil.IS_SIGNED_KEY));
     assertEquals(expectedSignatureCount != 0, details.get(SignatureUtil.IS_SIGNED_KEY));
     if (expectedSignatureCount != 0) {
-      assertThat(details, hasKey(SignatureUtil.SIGNATURE_DETAILS_KEY));
       final Object signatureDetails = details.get(SignatureUtil.SIGNATURE_DETAILS_KEY);
-      assertThat(signatureDetails, instanceOf(List.class));
       final List<Map<String,Object>> signatureList = (List<Map<String,Object>>) signatureDetails;
       assertThat(signatureList.size(), equalTo(expectedSignatureCount));
       for (Map<String, Object> signature : signatureList) {
@@ -151,7 +149,20 @@ class TestPDFMatcher {
           assertThat(signature.get(SignatureUtil.SIGNATURE_DOCUMENT_COVERAGE_KEY), equalTo("WHOLE_DOCUMENT"));
           assertThat(signature.get(SignatureUtil.SIGNATURE_NUMBER_KEY), equalTo(1));
         }
+        System.out.println("Valid: " + signature.get(SignatureUtil.SIGNATURE_VALIDITY));
       }
+    }
+  }
+
+  @Test // TODO delete
+  void test() throws IOException {
+    Map<String, Object> result = ANALYZER.analyze(new File("src/test/resources/pdf/adbe.pkcs7.sha1.pdf"));
+    Map<String,Object> pdfDetails = (Map<String,Object>) result.get(PDFMatcher.DETAILS_KEY);
+    List<Map<String,Object>> sigDetails = (List<Map<String,Object>>) pdfDetails.get(SignatureUtil.SIGNATURE_DETAILS_KEY);
+    for (Map<String, Object> sigDetail : sigDetails) {
+      System.out.println(sigDetail.get(SignatureUtil.SIGNATURE_FILTER_KEY));
+      System.out.println(sigDetail.get(SignatureUtil.SIGNATURE_SUB_FILTER_KEY));
+      System.out.println(sigDetail.get(SignatureUtil.SIGNATURE_VALIDITY));
     }
   }
 

--- a/src/test/resources/pdf/signed.csv
+++ b/src/test/resources/pdf/signed.csv
@@ -1,5 +1,6 @@
-URL,signature-count
-https://github.com/levigo/sample-files/raw/main/pdf/PDF_signed_invisible.pdf,1
-https://github.com/levigo/sample-files/raw/main/pdf/PDF_signed_visible.pdf,1
-https://github.com/levigo/sample-files/raw/main/pdf/PDF_signed_invisible_visible.pdf,2
-https://github.com/levigo/sample-files/raw/main/pdf/PDF_unsigned.pdf,0
+URL,signature-count,valid
+https://github.com/levigo/sample-files/raw/main/pdf/PDF_signed_invisible.pdf,1,true
+https://github.com/levigo/sample-files/raw/main/pdf/PDF_signed_visible.pdf,1,true
+https://github.com/levigo/sample-files/raw/main/pdf/PDF_signed_invisible_visible.pdf,2,true
+https://github.com/levigo/sample-files/raw/main/pdf/PDF_unsigned.pdf,0,true
+https://github.com/levigo/sample-files/raw/main/pdf/PDF_signed_visible_broken_signature.pdf,1,false


### PR DESCRIPTION
Signaturen werden nun verifiziert. Dabei werden alle möglichen subfilter unterstützt. Die Implementierung ist stark von [PDFBox's ShowSignature.java](https://github.com/apache/pdfbox/blob/trunk/examples/src/main/java/org/apache/pdfbox/examples/signature/ShowSignature.java) inspiriert, allerdings in einigen Teilen noch nicht so detailiert gestaltet wie dort. Das betrifft vor allem die Überprüfung der certificate-chain (das wird in ShowSignature.java allerdings auch nur ohne Überprüfung des root-certificates gemacht) und auch die Überprüfung des timestamps.